### PR TITLE
adding route53 dns records (CNAMES)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 #  Local .terraform directories
+.terraform/
 **/.terraform/*
 
 # .tfstate files

--- a/modules/aws.tf
+++ b/modules/aws.tf
@@ -211,3 +211,38 @@ data "aws_iam_policy_document" "vault-server" {
 
   }
 
+resource "aws_route53_record" "hashiui" {
+  zone_id = "Z2VGUC188F45PC"
+  name    = "${var.namespace}-hashiui"
+  type    = "CNAME"
+  records = [aws_instance.workers.0.public_dns]
+  ttl     = "300"
+}
+resource "aws_route53_record" "fabio" {
+  zone_id = "Z2VGUC188F45PC"
+  name    = aws_alb.fabio.name
+  type    = "CNAME"
+  records = [aws_alb.fabio.dns_name]
+  ttl     = "300"
+}
+resource "aws_route53_record" "consul" {
+  zone_id = "Z2VGUC188F45PC"
+  name    = aws_alb.consul.name
+  type    = "CNAME"
+  records = [aws_alb.consul.dns_name]
+  ttl     = "300"
+}
+resource "aws_route53_record" "nomad" {
+  zone_id = "Z2VGUC188F45PC"
+  name    = aws_alb.nomad.name
+  type    = "CNAME"
+  records = [aws_alb.nomad.dns_name]
+  ttl     = "300"
+}
+resource "aws_route53_record" "vault" {
+  zone_id = "Z2VGUC188F45PC"
+  name    = aws_alb.vault.name
+  type    = "CNAME"
+  records = [aws_alb.vault.dns_name]
+  ttl     = "300"
+}

--- a/modules/outputs.tf
+++ b/modules/outputs.tf
@@ -15,21 +15,21 @@ output "nomad_workers_ui" {
 }
 
 output "hashi_ui" {
-  value = "http://${aws_instance.workers.0.public_dns}:3000"
+  value = "http://${aws_route53_record.hashiui.fqdn}:3000"
 }
 
 output "fabio_lb" {
-  value = "http://${aws_alb.fabio.dns_name}:9999"
+  value = "http://${aws_route53_record.fabio.fqdn}:9999"
 }
 
 output "vault_ui" {
-  value = "http://${aws_alb.vault.dns_name}:8200"
+  value = "http://${aws_route53_record.vault.fqdn}:8200"
 }
 
 output "nomad_ui" {
-  value = "http://${aws_alb.nomad.dns_name}:4646"
+  value = "http://${aws_route53_record.nomad.fqdn}:4646"
 }
 
 output "consul_ui" {
-  value = "http://${aws_alb.consul.dns_name}:8500"
+  value = "http://${aws_route53_record.consul.fqdn}:8500"
 }


### PR DESCRIPTION
zone_id is hardcoded... Not something that should change, but we should look at how to import this from the se-demos stack